### PR TITLE
Link to actual Jenkins plugin

### DIFF
--- a/activity-execution.html
+++ b/activity-execution.html
@@ -24,7 +24,7 @@
       <div class="container bg-shade">
         <h1 class="section-heading">Implementations</h1>
         <ul style="list-style-type:none">
-          <li><a href="https://github.com/eiffel-community/eiffel-jenkins-plugin">Eiffel Jenkins Plugin</a></li>
+          <li><a href="https://github.com/jenkinsci/eiffel-broadcaster-plugin">Eiffel Broadcaster Jenkins plugin</a></li>
         </ul>
       </div>
     </section>

--- a/activity-orchestration.html
+++ b/activity-orchestration.html
@@ -24,7 +24,7 @@
       <div class="container bg-shade">
         <h1 class="section-heading">Implementations</h1>
         <ul style="list-style-type:none">
-          <li><a href="https://github.com/eiffel-community/eiffel-jenkins-plugin">Eiffel Jenkins Plugin</a></li>
+          <li><a href="https://github.com/jenkinsci/eiffel-broadcaster-plugin">Eiffel Broadcaster Jenkins plugin</a></li>
         </ul>
       </div>
     </section>


### PR DESCRIPTION
### Applicable Issues
Fixes #6 

### Description of the Change
Use the correct URL in the links to the Eiffel Jenkins plugin. The repository previously linked to (in the eiffel-community GitHub organization) is just an empty placeholder. The active repository resides in the jenkinsci organization.

### Alternate Designs
None.

### Benefits
Link leads to a useful location.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
