### PR TITLE
Add SHOULD recommendation for publisher routing key schema

### DIFF
--- a/rabbitmq-message-broker.html
+++ b/rabbitmq-message-broker.html
@@ -43,6 +43,15 @@
             <li>It SHALL ensure that published event types defined in edition-toulouse of the <a href="https://github.com/eiffel-community/eiffel">Eiffel protocol</a> comply with protocol definitions.</li>
             <li>It MAY publish messages on Eiffel-like syntax, containing event types not defined in the <a href="https://github.com/eiffel-community/eiffel">Eiffel protocol</a>, as well as other other types of messages completely unrelated to the Eiffel protocol.</li>
             <li>It SHALL support routing keys.</li>
+            <li>
+              It SHOULD use a routing key on the form <code>eiffel.&lt;family&gt;.&lt;type&gt;.&lt;tag&gt;.&lt;domainid&gt;</code>, where:
+              <ul>
+                <li><code>family</code> is the non-empty name of a group of Eiffel events to which the current event belongs. The families have not been defined in Sepia but may be in the future. Implementations may choose to use a fixed string in this field.</li>
+                <li><code>type</code> is the type of the published Eiffel event (i.e. its <code>meta.type</code> member), e.g. EiffelArtifactCreatedEvent.</li>
+                <li><code>tag</code> is an implementation-specific tag. It can be any non-empty string but must not contain a period.</li>
+                <li><code>domainid</code> is the non-empty string representing the domain the event applies to. It corresponds to the <code>meta.source.domainId</code> member of an Eiffel event.</li>
+              </ul>
+            </li>
             <li>It SHALL support named exchanges.</li>
             <li>Unless stated otherwise in its documentation, it SHALL NOT make any assumptions as to the presence, absence or nature of other producers connected to the same exchange.</li>
           </ul>


### PR DESCRIPTION
### Applicable Issues
Fixes #8 

### Description of the Change
A SHOULD recommendation for the routing key schema used by publishers is added to the RabbitMQ broker documentation. It's a simple schema that any publisher will be able to adhere to. It's similar to [what REMReM uses](https://github.com/eiffel-community/eiffel-remrem-semantics/blob/master/wiki/routingAndBindingKeyConcepts.md#eiffel-routing-convention) but is slightly simplified.

### Alternate Designs
Ideally we would've been able to standardize REMReM's schema as-is, but the split of the event type into "family" and "type", where e.g. EiffelActivityCanceledEvent becomes (activity, canceled), makes life harder for both consumers and producers. If a consumer is interested in all activity events multiple bindings can be applied to the queue.

### Benefits
When publishers follow this recommendation consumers will be able to filter inbound events.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
