### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @eiffel-community/eiffel-sepia-maintainers will be
+# requested for review when someone opens a pull request.
+
+* @eiffel-community/eiffel-sepia-maintainers


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/community/issues/7

### Description of the Change
Having a [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) is the repository makes it easier for both humans and machines to figure out who the maintainers are. Also, newly opened PRs will have the correct people added as reviewers. The file maps all paths to the repository maintainers' GitHub team.

A separate PR has been filed for the master branch. CODEOWNERS files only apply to the branch they reside on.

### Alternate Designs
None.

### Benefits
- Easier to locate who the maintainers are.
- PR reviewers are added automatically.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
